### PR TITLE
Remove reset_sii_keys button from account invoice views

### DIFF
--- a/view/account_invoice_form.xml
+++ b/view/account_invoice_form.xml
@@ -25,7 +25,6 @@ contains the full copyright notices and license terms. -->
           <field name="sii_state"/>
           <label name="sii_pending_sending"/>
           <field name="sii_pending_sending"/>
-          <button name="reset_sii_keys" colspan="4"/>
         </page>
     </xpath>
 </data>

--- a/view/account_invoice_list.xml
+++ b/view/account_invoice_list.xml
@@ -8,6 +8,5 @@ contains the full copyright notices and license terms. -->
       <field name="sii_communication_type"/>
       <field name="sii_state"/>
       <field name="sii_pending_sending"/>
-      <button name="reset_sii_keys" tree_invisible="1"/>
     </xpath>
 </data>


### PR DESCRIPTION
After the refactor from the reset_keys button to a wizard the views stil have the button.
In this case the test_view test from ModuleTestCase is broken.